### PR TITLE
Allow metadata retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+* Added `dry` command (do everything except write files).
+
 ## 2.1.0 (June 19, 2022)
 * Added AVIF support.
 * Added GIF support.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Global Options
   --compressionLevel, -c  zlib compression level                               [number] [default: 6]
   --delay                 Delay(s) between animation frames                                 [number]
   --density               DPI for vector images                               [number] [default: 72]
+  --dry, -n               Do everything except write files                                 [boolean]
   --format, -f            Force output to a given format
     [choices: "input", "avif", "gif", "heif", "jpeg", "jpg", "png", "raw", "tiff", "webp"] [default:
                                                                                             "input"]

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -69,6 +69,13 @@ const options = {
     type: 'number'
   },
 
+  dry: {
+    alias: 'n',
+    desc: 'Do everything except write files',
+    group: _global,
+    type: 'boolean'
+  },
+
   // @see https://sharp.pixelplumbing.com/api-output#toformat
   format: {
     alias: 'f',

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -109,10 +109,9 @@ module.exports = {
         })
       }
 
-      // Write, attach info and return.
+      // Write to file unless we're doing a dry run, attach info and return.
       fs.createReadStream(src).pipe(transformer)
-      return transformer
-        .toFile(dest)
+      return Promise.resolve(args.dry ? transformer : transformer.toFile(dest))
         .then((info) => Object.assign(info, { src, path: dest }))
     })
     return Promise.all(promises)

--- a/test/convert.js
+++ b/test/convert.js
@@ -95,6 +95,12 @@ describe('convert', () => {
       return convert
         .files([input], dest, {})
     })
+    it('must not write to disk if the dry flag is set', () => {
+      const out = path.join(dest, `{name}-${Math.random()}{ext}`)
+      return convert
+        .files([input], out, { dry: true })
+        .then(() => expect(fs.existsSync(out)).to.be.false())
+    })
   })
   describe('stream', () => {
     // Default output.


### PR DESCRIPTION
## This Pull Request:
- [x] Adds a `dry` flag that, when set, allows you to do dry runs (i.e. do everything except write files).
- [ ] Adds a `--printMetadata` flag that, when set, prints a metadata structure (JSON) containing metadata of the input and output.

## Things to Note:
- The dry run flag is required if you just want to get input metadata and not actually transform the input - this would be something like `sharp -i ./input.jpg -o ./ --dry --printMetadata`.
- Solves #48.